### PR TITLE
Upgrade to Twitter API v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,9 +206,14 @@ This assumes you already have an access token, obtained by any method
 described above.
 
 ```lua
+local JSON = require("JSON")
 local bblt = require("bbl-twitter")
 local c = bblt.client(config.consumer_key, config.consumer_secret, config.token_key, config.token_secret)
-c:signed_request("/1.1/statuses/update.json", {status = "Look ma, tweets from Lua!"}, "POST")
+local body = JSON:encode({text = "Hello world!"})
+c:signed_request("/2/tweets", {
+      ["Content-Type"] = "application/json",
+      ["Content-Length"] = string.len(body),
+		}, 'POST', JSON:encode(body))
 ```
 
 ### Provide bbl-twitter options in a global 'twitter_config' table


### PR DESCRIPTION
With Twitter having depracated API v1 for tweeting an upgrade to API v2 is needed.